### PR TITLE
Fix GitBook links and reference to the repo

### DIFF
--- a/docs/guides/Debugging_With_Duktape.md
+++ b/docs/guides/Debugging_With_Duktape.md
@@ -56,7 +56,7 @@ The following option should be added to the `output` key in your webpack config:
 You also need to ensure that your bundle is not minified, this can be achieved by building your JS bundle with `webpack --mode=development`.
 In the case of the `GainPlugin` example this can be achieved by running `npm run start` in `GainPlugin/jsui`.
 
-The `webpack.config.js` template provided by React-JUCE enables all of this for you. See: [Starting a new Project](New_Project.md) for a project
+The `webpack.config.js` template provided by React-JUCE enables all of this for you. See: [Starting a new Project](Integrating_Your_Project.md) for a project
 template setup which includes debugger support. Project template files are available under `react-juce/packages/react-juce/template`.
 
 Example `webpack.config.js`:

--- a/docs/guides/Getting_Started.md
+++ b/docs/guides/Getting_Started.md
@@ -17,19 +17,19 @@ itself. React-JUCE's git repository contains necessary submodules, so we'll need
 collect those as well, which we can do one of two ways:
 
 ```bash
-$ git clone --recurse-submodules git@github.com:nick-thompson/react-juce.git
+$ git clone --recurse-submodules git@github.com:JoshMarler/react-juce.git 
 ```
 
 or
 
 ```bash
-$ git clone git@github.com:nick-thompson/react-juce.git
+$ git clone git@github.com:JoshMarler/react-juce.git 
 $ cd react-juce
 $ git submodule update --init --recursive
 ```
 
 Note that the `git@github.com` prefix here indicates cloning via SSH. If you prefer
-to work with git via HTTPS you'll want to swap in `https://github.com/nick-thompson/react-juce.git`
+to work with git via HTTPS you'll want to swap in `https://github.com/JoshMarler/react-juce`
 in the above commands.
 
 At this point, we've got everything ready to get our project up and running. Let's

--- a/docs/guides/Running_the_Examples.md
+++ b/docs/guides/Running_the_Examples.md
@@ -26,7 +26,7 @@ To get the GainPlugin up and running for the first time, we have to first perfor
 that compilation step. So, from the root of the `React-JUCE` git repository:
 
 ```bash
-$ cd examples/GainPlugin/Source/jsui/
+$ cd examples/GainPlugin/jsui/
 ```
 
 The `jsui/` directory here is the top level directory of all the
@@ -39,7 +39,7 @@ $ npm install
 $ npm run build
 ```
 
-At this point, you'll see an output file in `examples/GainPlugin/Source/jsui/build/js/`. That file location is important, because that's where the native code looks for executing the output file.
+At this point, you'll see an output file in `examples/GainPlugin/jsui/build/js/`. That file location is important, because that's where the native code looks for executing the output file.
 
 ### Native
 

--- a/docs/guides/Running_the_Examples.md
+++ b/docs/guides/Running_the_Examples.md
@@ -67,4 +67,4 @@ and redraw your interface.
 
 Now that you're up and running, take a minute to tweak the GainPlugin React
 application to get a sense of the workflow! When you're done, let's move on to
-the next step, [adding React-JUCE to your own project](New_Project.md).
+the next step, [adding React-JUCE to your own project](Integrating_Your_Project.md).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nick-thompson/react-juce.git"
+    "url": "git+https://github.com/JoshMarler/react-juce.git"
   },
   "devDependencies": {
     "husky": "^4.3.8",


### PR DESCRIPTION
Closes #285 
Closes #284

I fixed the various paths mentioned in the issues above.

I also changed the various mention to the old repo under `https://github.com/nick-thompson/react-juce.git` into `https://github.com/JoshMarler/react-juce/`. Although these were working fine, it might be confusing for users.